### PR TITLE
Fix interminable loading screen by making grammarIdentifier optional

### DIFF
--- a/BunProKit/Sources/BunProKit/BPKGrammar.swift
+++ b/BunProKit/Sources/BunProKit/BPKGrammar.swift
@@ -19,7 +19,7 @@ public struct BPKSentence: Codable {
     }
 
     public let identifier: Int64
-    public let grammarIdentifier: Int64
+    public let grammarIdentifier: Int64?
     public let japanese: String
     public let english: String
     public let structure: String
@@ -41,7 +41,7 @@ public struct BPKLink: Codable {
     }
 
     public let identifier: Int64
-    public let grammarIdentifier: Int64
+    public let grammarIdentifier: Int64?
     public let site: String
     public let description: String
     public let link: String

--- a/BunProKit/Sources/BunProKit/BPKReview.swift
+++ b/BunProKit/Sources/BunProKit/BPKReview.swift
@@ -33,7 +33,7 @@ public struct BPKReview: Codable {
     public let identifier: Int64
     public let userIdentifier: Int64
     public let studyQuenstionIdentifier: Int64?
-    public let grammarIdentifier: Int64
+    public let grammarIdentifier: Int64?
     public let reviewType: ReviewType? // Self study does not have a type
     public let timesCorrect: Int64
     public let timesIncorrect: Int64

--- a/iOS/Supporting Files/Model/Review+Initializer.swift
+++ b/iOS/Supporting Files/Model/Review+Initializer.swift
@@ -15,7 +15,7 @@ extension Review {
         identifier = review.identifier
         complete = review.complete ?? true
         createdDate = review.createdDate
-        grammarIdentifier = review.grammarIdentifier
+        grammarIdentifier = review.grammarIdentifier ?? 0
         lastStudiedDate = review.lastStudiedDate
         nextReviewDate = review.nextReviewDate
         readingIdentifiers = review.readingsIdentifiers as NSArray?


### PR DESCRIPTION
Currently, there seems to be a bug where manual vocab is causing the reviews from the API to not get decoded properly. This seems to be because the grammarIdentifier is nil. This PR prevents the failure of the decoder by making the grammarIdentifier optional and nil coalescing to zero in the init.


Edit: Link to relevant feedback post on the community board: https://community.bunpro.jp/t/ios-app-feedback/137/124?u=number2dadd